### PR TITLE
Die if the SSH command is empty.

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -95,6 +95,10 @@ def post_receive():
 def git_serve():
     command = os.getenv("SSH_ORIGINAL_COMMAND")
 
+    # quit if there's no command
+    if not command:
+        die("Authenticated as %s. This remote user does not have shell access." % user.identifier)
+
     # split the command
     action, repo = command.split()
 


### PR DESCRIPTION
Added a check to make sure the SSH command isn't empty

Fixes the following error if one tries to SSH into the server with a git user:

```
Traceback (most recent call last):
  File "/Users/git/mini/hooks.py", line 149, in <module>
    git_serve()
  File "/Users/git/mini/hooks.py", line 99, in git_serve
    action, repo = command.split()
AttributeError: 'NoneType' object has no attribute 'split'
```
